### PR TITLE
fix: Do generate some UUID instead of using current PID

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
     image: quay.io/strimzi/kafka:0.47.0-kafka-4.0.0
     command: [
       "sh", "-c",
-      "./bin/kafka-storage.sh format --standalone -t $$(./bin/kafka-storage.sh random-uuid) -c ./config/server.properties && ./bin/kafka-server-start.sh ./config/server.properties"
+      "./bin/kafka-storage.sh format --standalone -t $(./bin/kafka-storage.sh random-uuid) -c ./config/server.properties && ./bin/kafka-server-start.sh ./config/server.properties"
     ]
     ports:
     - "9092:9092"


### PR DESCRIPTION
Think I've found some flaw where the wrong random number gets created.

I was curious about the `$$` notation. Turns out this is the shortcut to return the current ProcessId (of the shell).

What happens on my machine:

```bash
echo "$$(./bin/kafka-storage.sh random-uuid)"
10354(./bin/kafka-storage.sh random-uuid)
```

Open another shell, the PID changes. (I guess in Docker context the PID stays always at `1`?)